### PR TITLE
Fix asset download for private repositories

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -4,6 +4,7 @@ use std::fmt::Display;
 /// GitHub release asset
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Asset {
+    pub id: u64,
     pub name: String,
     pub browser_download_url: String,
     pub size: u64,


### PR DESCRIPTION
## What's changed
Use GitHub API endpoint with asset ID instead of browser_download_url to ensure authentication header is preserved. The browser_download_url redirects to a CDN where the auth header is not forwarded, causing 404 errors for private repos.